### PR TITLE
Add lwt dependency to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an end to end "smoketest" for Mirage/Solo5.
 
 TL;DR on how to currently build/run in case I pointed you here:
 
-- `opam install dune shexp` if you don't have them already
+- `opam install dune lwt shexp` if you don't have them already
 - `dune exec bin/main.exe`
 
 This will build the test unikernel in `./unikernel` in a local switch created from scratch, with the package "universe" defined in `./universe` and then attempt to run the smoketest. 


### PR DESCRIPTION
lwt-unix is needed from `client`.